### PR TITLE
remove duplication from PuppetfileNotFound friendly message

### DIFF
--- a/lib/henson/friendly_errors.rb
+++ b/lib/henson/friendly_errors.rb
@@ -9,7 +9,7 @@ module Henson
       Henson.ui.warning e.backtrace.join("\n")
       exit e.exit_code
     rescue PuppetfileNotFound, ModulefileNotFound => e
-      Henson.ui.error "Expected to find #{e.message}, but does not exist!"
+      Henson.ui.error "#{e.message}, but it does not exist!"
       exit e.exit_code
     rescue ModuleNotFound => e
       Henson.ui.error "Could not find module: #{e.message}"


### PR DESCRIPTION
errors looked like the following when a Puppetfile was missing.

```
Expected to find: Expected a Puppetfile at /home/lunix/projects/henson/Puppetfile!, but does not exist!
```

This just cleans that up.
