### PR TITLE
Path source should symlink

### DIFF
--- a/acceptance/henson_install_spec.rb
+++ b/acceptance/henson_install_spec.rb
@@ -28,7 +28,7 @@ describe "henson install" do
   end
 
   it "should have ssh module" do
-    expect(Pathname.new("#{project}/shared/ssh")).to be_directory
+    expect(Pathname.new("#{project}/shared/ssh")).to be_symlink
   end
 
   it "should have stdlib module" do

--- a/lib/henson/source/path.rb
+++ b/lib/henson/source/path.rb
@@ -5,7 +5,7 @@ module Henson
     class Path < Generic
       attr_reader :path, :name
 
-      def initialize(name, path)
+      def initialize name, path
         @path = path
         @name = name
 
@@ -21,9 +21,8 @@ module Henson
       end
 
       def install!
-        Henson.ui.debug "Installing #{name} from #{path} into #{Henson.settings[:path]}..."
-        Henson.ui.info  "Installing #{name} from #{path}..."
-        FileUtils.cp_r path, Henson.settings[:path]
+        Henson.ui.debug "Symlinking #{path} to #{install_path}"
+        FileUtils.ln_sf path, install_path.to_path
       end
 
       def versions
@@ -39,6 +38,10 @@ module Henson
 
       def path_exists?
         path && File.directory?(path)
+      end
+
+      def install_path
+        @install_path ||= Pathname.new(Henson.settings[:path]) + path
       end
 
       def version_from_modulefile

--- a/lib/henson/source/path.rb
+++ b/lib/henson/source/path.rb
@@ -41,7 +41,7 @@ module Henson
       end
 
       def install_path
-        @install_path ||= Pathname.new(Henson.settings[:path]) + path
+        @install_path ||= Pathname.new(Henson.settings[:path]) + name
       end
 
       def version_from_modulefile

--- a/spec/henson/source/forge_spec.rb
+++ b/spec/henson/source/forge_spec.rb
@@ -34,7 +34,11 @@ describe Henson::Source::Forge do
     let(:ui) { mock }
 
     before do
-      Henson.ui = ui
+      Henson.stubs(:ui).returns(ui)
+    end
+
+    after do
+      Henson.unstub(:ui)
     end
 
     it "should make an API request to download the module" do

--- a/spec/henson/source/github_spec.rb
+++ b/spec/henson/source/github_spec.rb
@@ -40,7 +40,11 @@ describe Henson::Source::GitHub do
     end
 
     before do
-      Henson.ui = ui
+      Henson.stubs(:ui).returns(ui)
+    end
+
+    after do
+      Henson.unstub(:ui)
     end
 
     it "sends an API request for tags" do
@@ -68,7 +72,11 @@ describe Henson::Source::GitHub do
     let(:ui) { mock }
 
     before do
-      Henson.ui = ui
+      Henson.stubs(:ui).returns(ui)
+    end
+
+    after do
+      Henson.unstub(:ui)
     end
 
     it "should make an API request to download the module" do

--- a/spec/henson/source/path_spec.rb
+++ b/spec/henson/source/path_spec.rb
@@ -1,16 +1,16 @@
 require "spec_helper"
 
 describe Henson::Source::Path do
-  let(:source) do
+  subject(:it) {
     Henson::Source::Path.new("foobar", "spec/fixtures/modules/foobar")
-  end
+  }
 
   it "can be instantiated" do
-    expect(source).to_not be_nil
+    expect(it).to_not be_nil
   end
 
   it "is a subclass of Henson::Source::Generic" do
-    expect(source).to be_a(Henson::Source::Generic)
+    expect(it).to be_a(Henson::Source::Generic)
   end
 
   it "raises an error if the path does not exist" do
@@ -21,52 +21,70 @@ describe Henson::Source::Path do
 
   context "#fetch!" do
     it "is a noop" do
-      expect(source.fetch!).to be_nil
+      expect(it.fetch!).to be_nil
     end
   end
 
   context "#install!" do
-    it "logs an install message"
+    let(:ui) { mock }
+
+    before do
+      Henson.stubs(:ui).returns(ui)
+    end
+
+    after do
+      Henson.unstub(:ui)
+    end
+
+    it "logs an install message" do
+      ui.expects(:debug).
+        with("Symlinking #{it.send(:path)} to #{it.send(:install_path)}")
+
+      FileUtils.expects(:ln_sf).
+        with(it.send(:path), it.send(:install_path).to_path)
+
+      it.install!
+    end
   end
 
   context "versions" do
     it "returns an array that contains version from modulefile" do
-      source.stubs(:version_from_modulefile).returns("1.0.0")
-      expect(source.versions).to eq(["1.0.0"])
+      it.stubs(:version_from_modulefile).returns("1.0.0")
+      expect(it.versions).to eq(["1.0.0"])
     end
   end
 
   context "valid?" do
     it "returns true if path_exists? is true" do
-      source.stubs(:path_exists?).returns(true)
-      expect(source.send(:valid?)).to be_true
+      it.stubs(:path_exists?).returns(true)
+      expect(it.send(:valid?)).to be_true
     end
 
     it "returns false if path_exists? is false" do
-      source.stubs(:path_exists?).returns(false)
-      expect(source.send(:valid?)).to be_false
+      it.stubs(:path_exists?).returns(false)
+      expect(it.send(:valid?)).to be_false
     end
   end
 
   context "path_exists?" do
     it "returns true if path is defined and is a directory" do
-      expect(source.send(:path_exists?)).to be_true
+      expect(it.send(:path_exists?)).to be_true
     end
 
     it "returns false if path is not a directory" do
-      source.stubs(:path).returns("/not/a/real/path")
-      expect(source.send(:path_exists?)).to be_false
+      it.stubs(:path).returns("/not/a/real/path")
+      expect(it.send(:path_exists?)).to be_false
     end
   end
 
   context "version_from_modulefile" do
     it "parses the Modulefile to get the version string" do
-      expect(source.send(:version_from_modulefile)).to eq("0.0.1")
+      expect(it.send(:version_from_modulefile)).to eq("0.0.1")
     end
 
     it "defaults to 0 if modulefile does not exist" do
-      source.stubs(:path).returns("/not/a/real/path")
-      expect(source.send(:version_from_modulefile)).to eq("0")
+      it.stubs(:path).returns("/not/a/real/path")
+      expect(it.send(:version_from_modulefile)).to eq("0")
     end
   end
 end

--- a/spec/henson/source/path_spec.rb
+++ b/spec/henson/source/path_spec.rb
@@ -19,6 +19,12 @@ describe Henson::Source::Path do
     }.to raise_error(Henson::ModuleNotFound, "/does/not/exist")
   end
 
+  describe "#fetched?" do
+    it "should be true" do
+      expect(it.fetched?).to be_true
+    end
+  end
+
   context "#fetch!" do
     it "is a noop" do
       expect(it.fetch!).to be_nil
@@ -74,6 +80,17 @@ describe Henson::Source::Path do
     it "returns false if path is not a directory" do
       it.stubs(:path).returns("/not/a/real/path")
       expect(it.send(:path_exists?)).to be_false
+    end
+  end
+
+  describe "#install_path" do
+    it "should be a Pathname" do
+      expect(it.send(:install_path)).to be_a(Pathname)
+    end
+
+    it "returns the expected install path" do
+      expect(it.send(:install_path).to_path).to \
+        eq("#{Henson.settings[:path]}/foobar")
     end
   end
 

--- a/spec/henson/source/tarball_spec.rb
+++ b/spec/henson/source/tarball_spec.rb
@@ -131,7 +131,11 @@ describe Henson::Source::Tarball do
     let(:ui) { mock }
 
     before do
-      Henson.ui = ui
+      Henson.stubs(:ui).returns(ui)
+    end
+
+    after do
+      Henson.unstub(:ui)
     end
 
     it "should be able to extract files" do
@@ -174,11 +178,6 @@ describe Henson::Source::Tarball do
   end
 
   describe "#cache_dir" do
-    before do
-      Henson.expects(:settings).
-        returns({ :no_cache => false, :cache_path => "/cache_path" })
-    end
-
     it "should return a Pathname object" do
       expect(it.send(:cache_dir)).to be_a(Pathname)
     end
@@ -228,10 +227,6 @@ describe Henson::Source::Tarball do
   end
 
   describe "#install_path" do
-    before do
-
-    end
-
     it "should return a Pathname object" do
       expect(it.send(:install_path)).to be_a(Pathname)
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ require "rubygems"
 require "simplecov"
 
 SimpleCov.start do
+  add_filter "/spec/"
   add_filter "/vendor/gems/"
 end
 


### PR DESCRIPTION
Right now it does a copy of the directory which doesn't really mimic Bundler's behavior well. I think Bundler's handling this right.
