### PR TITLE
Make Puppetfile :git compatible with all the other tools

### DIFF
--- a/acceptance/fixtures/Puppetfile
+++ b/acceptance/fixtures/Puppetfile
@@ -7,9 +7,9 @@ mod "puppetlabs/cloud_provisioner", "1.0.5"
 mod "ssh",       :path => "#{File.expand_path("../modules/ssh", __FILE__)}"
 
 # git
-mod "stdlib",    :git => { :repo => "git://github.com/puppetlabs/puppetlabs-stdlib", :tag => "3.0.0" }
-mod "openstack", :git => { :repo => "git://github.com/puppetlabs/puppetlabs-openstack", :branch => "folsom" }
-mod "lvm",       :git => { :repo => "git://github.com/puppetlabs/puppetlabs-lvm", :ref => "8a7b20e3" }
+mod "stdlib",    :git => "git://github.com/puppetlabs/puppetlabs-stdlib", :tag => "3.0.0"
+mod "openstack", :git => "git://github.com/puppetlabs/puppetlabs-openstack", :branch => "folsom"
+mod "lvm",       :git => "git://github.com/puppetlabs/puppetlabs-lvm", :ref => "8a7b20e3"
 
 # github release/tag
 mod "boxen", "~> 0.1.0", :github => "boxen/puppet-boxen"

--- a/lib/henson/source.rb
+++ b/lib/henson/source.rb
@@ -11,7 +11,7 @@ module Henson
       if path = opts.delete(:path)
         Path.new name, path
       elsif git = opts.delete(:git)
-        Git.new name, git.delete(:repo), git
+        Git.new name, git, opts
       elsif forge = opts.delete(:forge)
         Forge.new name, requirement, forge
       elsif github = opts.delete(:github) || opts.delete(:github_tarball)


### PR DESCRIPTION
All the other tools that support `Puppetfile` treat git repositories differently. Switch to that syntax so we are compatible.
