### PR TITLE
Updates git repos based on branch to latest remote branch HEAD

### DIFF
--- a/lib/henson/cli.rb
+++ b/lib/henson/cli.rb
@@ -31,6 +31,8 @@ module Henson
       "Only output warnings and errors."
     method_option "debug", :type => :boolean, :banner =>
       "Turn on verbose output."
+    method_option "no-symlink", :type => :boolean, :banner =>
+      "Copy shared modules instead of symlink"
     method_option "local", :type => :boolean, :banner =>
       "Only check local cache source for modules."
     method_option "no-cache", :type => :boolean, :banner =>
@@ -45,6 +47,7 @@ module Henson
       Installer.clean!    if options[:clean]
 
       Henson.settings[:path] = options[:path] if options[:path]
+      Henson.settings[:symlink] = false if options[:"no-symlink"]
 
       Installer.install!
     end

--- a/lib/henson/installer.rb
+++ b/lib/henson/installer.rb
@@ -44,9 +44,10 @@ module Henson
     # mod - The PuppetModule to fetch.
     def self.fetch_module! mod
       if mod.needs_fetching?
+        Henson.ui.info "#{mod.name} is being updated"
         mod.fetch!
       else
-        Henson.ui.debug "#{mod} does not need fetching"
+        Henson.ui.debug "#{mod} #{mod.name} does not need fetching"
       end
     end
 
@@ -55,6 +56,7 @@ module Henson
     # mod - The PuppetModule to install.
     def self.install_module! mod
       if mod.needs_installing?
+        Henson.ui.info "#{mod.name} is being installed"
         mod.install!
       else
         install_path = "#{Henson.settings[:path]}/#{mod.name}"

--- a/lib/henson/settings.rb
+++ b/lib/henson/settings.rb
@@ -4,6 +4,7 @@ module Henson
       self.merge!(
         :quiet      => false,
         :verbose    => false,
+        :symlink    => true,
         :puppetfile => "#{Dir.pwd}/Puppetfile",
         :path       => "#{Dir.pwd}/shared",
         :cache_path => "#{Dir.pwd}/.henson/cache",

--- a/lib/henson/source/path.rb
+++ b/lib/henson/source/path.rb
@@ -21,8 +21,14 @@ module Henson
       end
 
       def install!
-        Henson.ui.debug "Symlinking #{path} to #{install_path}"
-        FileUtils.ln_sf path, install_path.to_path
+        if Henson.settings[:symlink]
+          Henson.ui.debug "Symlinking #{path} to #{install_path}"
+          FileUtils.ln_sf path, install_path.to_path
+        else
+          Henson.ui.debug "Installing #{name} from #{path} into #{Henson.settings[:path]}..."
+          Henson.ui.info  "Installing #{name} from #{path}..."
+          FileUtils.cp_r path, Henson.settings[:path]
+        end
       end
 
       def versions


### PR DESCRIPTION
Git branches as a source will now detect the remote HEAD as being newer and fetch/install when asked to henson install 
Added a new option to disable the symlink as this breaks things that do a shared folder mount like (like in a vagrant vm)
